### PR TITLE
chore: fix diagram URL

### DIFF
--- a/bpmn-js-app/src/app/app.component.ts
+++ b/bpmn-js-app/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'bpmn-js-angular';
-  diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
+  diagramUrl = 'https://cdn.statically.io/gh/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
   importError?: Error;
 
   handleImported(event) {


### PR DESCRIPTION
cdn.staticaly.com is not secured. Moreover, when you try to access it in http instead of https, it will redirect you to shady websites who'll try to make you install things, pretending your PC is infected by a virus