### PR TITLE
Added step to include style files in Angular.json to ## Integrating bpmn-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ cd bpmn-js-app
 
 ## Integrating bpmn-js
 
+Include the style files for diagram-js and bpmn in your [`Angular.json file`](./bpmn-js-app/angular.json) under projects > your project > architect > build > options > styles
+
+```json
+"styles": [
+              "node_modules/bpmn-js/dist/assets/diagram-js.css",
+              "node_modules/bpmn-js/dist/assets/bpmn-font/css/bpmn.css",
+              "src/styles.css"
+            ],
+```
+
 Create a component similar to [`DiagramComponent`](./bpmn-js-app/src/app/diagram/diagram.component.ts):
 
 ```typescript


### PR DESCRIPTION
### Proposed Changes

I added an extra step that was missing in the ReadMe when describing how to set up BPMN-js for an Angular project.
Without this step, the djs palette doesn't correctly render.

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
